### PR TITLE
Update imported package urls

### DIFF
--- a/bird.go
+++ b/bird.go
@@ -18,7 +18,7 @@ import (
 	"sync"
 
 	"github.com/veandco/go-sdl2/sdl"
-	img "github.com/veandco/go-sdl2/sdl_image"
+	"github.com/veandco/go-sdl2/img"
 )
 
 const (

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	"github.com/veandco/go-sdl2/sdl"
-	ttf "github.com/veandco/go-sdl2/sdl_ttf"
+	"github.com/veandco/go-sdl2/ttf"
 )
 
 func main() {

--- a/pipes.go
+++ b/pipes.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	"github.com/veandco/go-sdl2/sdl"
-	img "github.com/veandco/go-sdl2/sdl_image"
+	"github.com/veandco/go-sdl2/img"
 )
 
 type pipes struct {

--- a/scene.go
+++ b/scene.go
@@ -19,7 +19,7 @@ import (
 	"time"
 
 	"github.com/veandco/go-sdl2/sdl"
-	img "github.com/veandco/go-sdl2/sdl_image"
+	"github.com/veandco/go-sdl2/img"
 )
 
 type scene struct {


### PR DESCRIPTION
We have since updated the package names to match how Go packages are usually named. This pull request updates the imported package urls.