### PR TITLE
fixed to work with latest version of go_sdl2 bindings

### DIFF
--- a/bird.go
+++ b/bird.go
@@ -17,8 +17,8 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/veandco/go-sdl2/img"
 	"github.com/veandco/go-sdl2/sdl"
-	img "github.com/veandco/go-sdl2/sdl_image"
 )
 
 const (

--- a/pipes.go
+++ b/pipes.go
@@ -19,8 +19,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/veandco/go-sdl2/img"
 	"github.com/veandco/go-sdl2/sdl"
-	img "github.com/veandco/go-sdl2/sdl_image"
 )
 
 type pipes struct {


### PR DESCRIPTION
First of all, I've really enjoyed your just for func youtube series!

Since you've written the code for flappy-gopher the go bindings for sdl2 have changed.
 - The names of the folders containing image, ttf and mixer have changed to reflect their package names, thus the imports are failing.
 - Ensuring the SDL calls are run from main has been changed. Therefore the game never gets passed the startup screen. See issue #2 

I've tried to fix both issues. Now the game seems to run like it is intended again.
This was only the second time I've written a Go program, so I probably made plenty of mistakes.
Nevertheless this might be useful to future visitors trying to run flappy-gopher.