### PR TITLE
update sdl package refs

### DIFF
--- a/bird.go
+++ b/bird.go
@@ -17,8 +17,8 @@ import (
 	"fmt"
 	"sync"
 
+	img "github.com/veandco/go-sdl2/img"
 	"github.com/veandco/go-sdl2/sdl"
-	img "github.com/veandco/go-sdl2/sdl_image"
 )
 
 const (

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	"github.com/veandco/go-sdl2/sdl"
-	ttf "github.com/veandco/go-sdl2/sdl_ttf"
+	ttf "github.com/veandco/go-sdl2/ttf"
 )
 
 func main() {
@@ -83,7 +83,7 @@ func drawTitle(r *sdl.Renderer, text string) error {
 	defer f.Close()
 
 	c := sdl.Color{R: 255, G: 100, B: 0, A: 255}
-	s, err := f.RenderUTF8_Solid(text, c)
+	s, err := f.RenderUTF8Solid(text, c)
 	if err != nil {
 		return fmt.Errorf("could not render title: %v", err)
 	}

--- a/pipes.go
+++ b/pipes.go
@@ -19,8 +19,8 @@ import (
 	"sync"
 	"time"
 
+	img "github.com/veandco/go-sdl2/img"
 	"github.com/veandco/go-sdl2/sdl"
-	img "github.com/veandco/go-sdl2/sdl_image"
 )
 
 type pipes struct {

--- a/scene.go
+++ b/scene.go
@@ -18,8 +18,8 @@ import (
 	"log"
 	"time"
 
+	img "github.com/veandco/go-sdl2/img"
 	"github.com/veandco/go-sdl2/sdl"
-	img "github.com/veandco/go-sdl2/sdl_image"
 )
 
 type scene struct {


### PR DESCRIPTION
I was going through your flappy-gopher video (**loving** it so far btw!) to learn some Go and saw that the `go-sdl2` package changed since you did your video. This a simple change makes it "work" again.

I'm pretty keen to try out modules at some stage so I might make a PR or two as I go through your videos if you don't mind :)